### PR TITLE
Add PE checksum fixup to local signing command

### DIFF
--- a/cmdline/token/signcmd.go
+++ b/cmdline/token/signcmd.go
@@ -138,6 +138,17 @@ func signCmd(cmd *cobra.Command, args []string) error {
 		if err := transform.Apply(argOutput, mimeType, bytes.NewReader(blob)); err != nil {
 			return shared.Fail(err)
 		}
+		// if needed, do a final fixup step
+		if mod.Fixup != nil {
+			f, err := os.OpenFile(argOutput, os.O_RDWR, 0)
+			if err != nil {
+				return shared.Fail(err)
+			}
+			defer f.Close()
+			if err := mod.Fixup(f); err != nil {
+				return shared.Fail(err)
+			}
+		}
 		opts.Audit.Attributes["perf.size.patch"] = len(blob)
 	}
 	duration := time.Since(startTime)


### PR DESCRIPTION
This adds the PE checksum fixup to the local sign command. I noticed I was getting "odd write" errors with the remote signing command only (I have a PE that compiles with a 00000000 checksum half the time for some reason).