### PR TITLE
Fix uuid.NewV4() call caused by a library change

### DIFF
--- a/lib/authenticode/catalog.go
+++ b/lib/authenticode/catalog.go
@@ -53,7 +53,7 @@ func (cat *Catalog) makeCatalog() CertTrustList {
 	}
 	return CertTrustList{
 		SubjectUsage:     []asn1.ObjectIdentifier{OidCatalogList},
-		ListIdentifier:   uuid.NewV4().Bytes(),
+		ListIdentifier:   uuid.Must(uuid.NewV4()).Bytes(),
 		EffectiveDate:    time.Now().UTC(),
 		SubjectAlgorithm: pkix.AlgorithmIdentifier{Algorithm: memberOid, Parameters: x509tools.Asn1Null},
 		Entries:          append(cat.Sha2Entries, cat.Sha1Entries...),


### PR DESCRIPTION
Changes in library satori/go.uuid cause a build error. 

See issue: https://github.com/satori/go.uuid/issues/66