### PR TITLE
Breaking change in beevik/etree & RFC3161 support for ClickOnce

### DIFF
--- a/lib/appmanifest/signmanifest.go
+++ b/lib/appmanifest/signmanifest.go
@@ -209,7 +209,7 @@ func (m *SignedManifest) AddTimestamp(token *pkcs7.ContentInfoSignedData) error 
 	if err != nil {
 		return err
 	}
-	cs, err := pkcs9.VerifyMicrosoftToken(token, m.EncryptedDigest)
+	cs, err := VerifyTimestamp(token, m.EncryptedDigest, m.Signature.Intermediates)
 	if err != nil {
 		return fmt.Errorf("failed to validate timestamp: %s", err)
 	}

--- a/lib/appmanifest/signmanifest.go
+++ b/lib/appmanifest/signmanifest.go
@@ -155,7 +155,7 @@ func makeLicense(asi *etree.Element, subjectName, manifestHash string) (*etree.E
 // ManifestInformation contains a hash value which is, for some inane reason,
 // the same hash that the outer signature references but in reverse byte order.
 func makeManifestHash(sig *etree.Element) string {
-	dv := sig.FindElement("//DigestValue")
+	dv := sig.FindElement(".//DigestValue")
 	blob, _ := base64.StdEncoding.DecodeString(dv.Text())
 	for i := 0; i < len(blob)/2; i++ {
 		j := len(blob) - i - 1

--- a/lib/pkcs9/pkcs7.go
+++ b/lib/pkcs9/pkcs7.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/sassoftware/relic/lib/pkcs7"
@@ -182,7 +183,8 @@ func VerifyMicrosoftToken(token *pkcs7.ContentInfoSignedData, encryptedDigest []
 		return nil, err
 	}
 	if !bytes.Equal(content, encryptedDigest) {
-		return nil, errors.New("timestamp does not match the enclosing signature")
+		// return nil, errors.New("timestamp does not match the enclosing signature")
+		log.Printf("warning: timestamp does not match the enclosing signature")
 	}
 	hash, _ := x509tools.PkixDigestToHash(sig.SignerInfo.DigestAlgorithm)
 	var signingTime time.Time

--- a/lib/pkcs9/pkcs7.go
+++ b/lib/pkcs9/pkcs7.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/sassoftware/relic/lib/pkcs7"
@@ -183,8 +182,7 @@ func VerifyMicrosoftToken(token *pkcs7.ContentInfoSignedData, encryptedDigest []
 		return nil, err
 	}
 	if !bytes.Equal(content, encryptedDigest) {
-		// return nil, errors.New("timestamp does not match the enclosing signature")
-		log.Printf("warning: timestamp does not match the enclosing signature")
+		return nil, errors.New("timestamp does not match the enclosing signature")
 	}
 	hash, _ := x509tools.PkixDigestToHash(sig.SignerInfo.DigestAlgorithm)
 	var signingTime time.Time

--- a/lib/pkcs9/structs.go
+++ b/lib/pkcs9/structs.go
@@ -54,6 +54,7 @@ const (
 
 var (
 	OidKeyPurposeTimeStamping  = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+	OidTSTInfo                 = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 1, 4}
 	OidAttributeTimeStampToken = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 2, 14}
 	OidAttributeCounterSign    = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 6}
 

--- a/signers/appmanifest/signer.go
+++ b/signers/appmanifest/signer.go
@@ -66,7 +66,8 @@ func sign(r io.Reader, cert *certloader.Certificate, opts signers.SignOpts) ([]b
 	if cert.Timestamper != nil {
 		tsreq := &pkcs9.Request{
 			EncryptedDigest: signed.EncryptedDigest,
-			Legacy:          true,
+			Legacy:          false,
+			Hash:		 opts.Hash,
 		}
 		token, err := cert.Timestamper.Timestamp(opts.Context(), tsreq)
 		if err != nil {

--- a/signers/appmanifest/signer.go
+++ b/signers/appmanifest/signer.go
@@ -43,6 +43,7 @@ var AppSigner = &signers.Signer{
 }
 
 func init() {
+	AppSigner.Flags().Bool("rfc3161-timestamp", true, "(APPMANIFEST) Timestamp with RFC3161 server")
 	signers.Register(AppSigner)
 }
 
@@ -66,9 +67,10 @@ func sign(r io.Reader, cert *certloader.Certificate, opts signers.SignOpts) ([]b
 	if cert.Timestamper != nil {
 		tsreq := &pkcs9.Request{
 			EncryptedDigest: signed.EncryptedDigest,
-			Legacy:          false,
-			Hash:		 opts.Hash,
+			Legacy:          !opts.Flags.GetBool("rfc3161-timestamp"),
+			Hash:            opts.Hash,
 		}
+
 		token, err := cert.Timestamper.Timestamp(opts.Context(), tsreq)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Hey!

There's been a breaking change in beevik/etree (https://github.com/beevik/etree/releases/tag/v1.0.1), causing the paths starting with "//" to be interpreted as an absolute path. This caused a wrong DigestValue to be picked. Changed that now to ".//DigestValue" so it picks the DigestValue in the Authenticode Signature block as intented.

Microsoft has also moved on to using RFC3161 timestamping servers for their ClickOnce manifests, so requesting an RFC3161 timestamp for those tasks. This does break the verification somehow (probably because that was only applicable to the non-RFC3161 requests), so replaced that with a warning for now. The resulting signed manifests are properly signed and timestamped though.

If you can give me a few pointers on how to verify those timestamps properly, I'll make sure to address that as well!