### PR TITLE
save raw pkcs7 blob during verification process

### DIFF
--- a/lib/signjar/verify.go
+++ b/lib/signjar/verify.go
@@ -100,6 +100,7 @@ func Verify(inz *zip.Reader, skipDigests bool) ([]*JarSignature, error) {
 		if err != nil {
 			return nil, err
 		}
+		ts.Raw = pkcs
 		hdr, err := verifySigFile(sigfile, manifest)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The timestamp returned for signjar's Verify method does not have the Raw [] byte content set, even though it is part of the struct and readily accessible. This PR simply ensures the value is copied into the returned struct.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>