### PR TITLE
fix: Adds missing build number to ./scripts/version.sh

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-git describe --tags --dirty=+ |sed -e 's/-\([0-9]*\).*/+/' | sed -e 's/^v//'
+git describe --tags --dirty=+ |sed -e 's/-\([0-9]*\).*/+\1/' | sed -e 's/^v//'


### PR DESCRIPTION
In ./scripts/version.sh, non-tagged builds omit the number of commits in the resulting version.
ex. building master simply outputs `7.3.0+` without the number of commits.

```
example:
$ git describe --tags --dirty=+
v7.4.1-4-gde63e37

before:
v7.4.1-4-gde63e37 -> 7.4.1+

after:
v7.4.1-4-gde63e37 -> 7.4.1+4
```