### PR TITLE
fix(./token/p11token/rsa.go): toRsaKey exponent []byte to int conversion issue

### DIFF
--- a/token/p11token/rsa.go
+++ b/token/p11token/rsa.go
@@ -35,7 +35,7 @@ func (key *Key) toRsaKey() (crypto.PublicKey, error) {
 		return nil, errors.New("Unable to retrieve RSA public key")
 	}
 	n := new(big.Int).SetBytes([]byte(modulus))
-	e := int(attrToInt(exponent))
+	e := int(new(big.Int).SetBytes(exponent).Int64())
 	return &rsa.PublicKey{N: n, E: e}, nil
 }
 


### PR DESCRIPTION
Fixes #12. 

A `certificate does not match key in token` error pops up when attempting to sign files using a pkcs11 token with an RSA key. 

Dumping x509tools.SameKey public keys showed a problem with the rsa.PublicKey.E being different between both keys.
Result was `16777472 (0x01000100)` from the RSA token vs `65537 (0x00010001)` from certificate file, showing an endianness issue.