### PR TITLE
Fix stream reading in comdoc

### DIFF
--- a/lib/comdoc/stream.go
+++ b/lib/comdoc/stream.go
@@ -94,7 +94,13 @@ func (sr *streamReader) Read(d []byte) (copied int, err error) {
 			return copied, errors.New("unexpected end to stream")
 		}
 		if err := sr.readSector(sr.nextSector, sr.buf); err != nil {
-			return copied, err
+			// If the error is not an EOF, return it now. However,
+			// if it is an EOF, ignore it so the buffer can be
+			// copied into the destination and remaining bytes
+			// can be updated
+			if err != io.EOF {
+				return copied, err
+			}
 		}
 		copy(d, sr.buf)
 		copied += n


### PR DESCRIPTION
This PR resolves the issue described in #17. When reading a stream and a partial sector read is required, if that read is at the end of the file it will result in an `io.EOF` error. That error will be returned immediately with only the bytes read _prior_ to the sector read. The `io.EOF` tells the reader there is no more data which can cause unexpected errors (like the missed writing `n` bytes in the case of `archive/tar` ). 

To resolve this, when reading the partial sector an error is only returned if it's not an `io.EOF` error. If the file read reaches EOF, it can be ignored so the data read from the sector can be copied into whatever space remains in the buffer and the rest can stored for the next read. If the buffer has space for all the data from the sector, then the next call will result in an `io.EOF` as `remaining` will be zero at that point.
