### PR TITLE
Fix xar signing with timestamp enabled

### DIFF
--- a/lib/fruit/xar/sign.go
+++ b/lib/fruit/xar/sign.go
@@ -133,7 +133,7 @@ func reserveSignatures(toc *etree.Element, hashType crypto.Hash, certs []*x509.C
 		added++
 	}
 	// reserve space for CMS
-	cmsSize := int64(4096)
+	cmsSize := int64(6144)
 	for _, cert := range certs {
 		cmsSize += int64(len(cert.Raw))
 	}


### PR DESCRIPTION
When signing is configured with timestamp enabled it will fail to write the signature due to inadequate space. Adjusting the size provides enough space for it to be written successfully. I'm unsure if a different value makes more sense for reasons I didn't find but this adjustment does work.

When attempting to sign on master an error is encountered:

```
➜ ./relic sign -c ./config.yml --file ./test.pkg --output ./test.signed.pkg --key macinstall
ERROR: signature overflows reserved space: have 6959 bytes, need 7649
```

When signing with this adjustment it succeeds: 

```
➜ ./relic sign -c ./config.yml --file ./test.pkg --output ./test.signed.pkg --key macinstall
Signed ./test.pkg
```