### PR TITLE
Allow signing JAR files (like Android application bundles) with modern keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type KeyConfig struct {
 	PgpCertificate  string   // Path to PGP certificate associated with this key
 	X509Certificate string   // Path to X.509 certificate associated with this key
 	KeyFile         string   // For "file" tokens, path to the private key
+	IsPkcs12        bool     // If true, key file contains PKCS#12 key and certificate chain
 	Roles           []string // List of user roles that can use this key
 	Timestamp       bool     // If true, attach a timestamped countersignature when possible
 	Hide            bool     // If true, then omit this key from 'remote list-keys'

--- a/doc/relic.yml
+++ b/doc/relic.yml
@@ -105,6 +105,8 @@ keys:
     token: file
     # Path to the private key file. The password is specified in the token configuration above.
     keyfile: ./keys/rsa1.key
+    # true if key file contains PKCS#12 key and certificate chain
+    ispkcs12: false
     # Same options as above: pgpcertificate, x509certificate, timestamp, roles
 
   my_gcloud_key:

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4
 	gopkg.in/yaml.v3 v3.0.1
 	howett.net/plist v1.0.0
+	software.sslmate.com/src/go-pkcs12 v0.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -706,3 +706,5 @@ howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
+software.sslmate.com/src/go-pkcs12 v0.2.0/go.mod h1:23rNcYsMabIc1otwLpTkCCPwUq6kQsTyowttG/as0kQ=

--- a/lib/certloader/pkcs12.go
+++ b/lib/certloader/pkcs12.go
@@ -22,7 +22,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	"golang.org/x/crypto/pkcs12"
+	"software.sslmate.com/src/go-pkcs12"
 
 	"github.com/sassoftware/relic/v7/lib/passprompt"
 	"github.com/sassoftware/relic/v7/lib/x509tools"

--- a/token/filetoken/filetoken.go
+++ b/token/filetoken/filetoken.go
@@ -99,9 +99,19 @@ func (tok *fileToken) GetKey(ctx context.Context, keyName string) (token.Key, er
 		}
 	}
 	*/
-	privateKey, err := certloader.ParseAnyPrivateKey(blob, tok.prompt)
-	if err != nil {
-		return nil, err
+	var privateKey crypto.PrivateKey
+	if keyConf.IsPkcs12 {
+		cert, err := certloader.ParsePKCS12(blob, tok.prompt)
+		if err != nil {
+			return nil, err
+		}
+		privateKey = cert.PrivateKey
+	} else {
+		var err error
+		privateKey, err = certloader.ParseAnyPrivateKey(blob, tok.prompt)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &fileKey{
 		keyConf: keyConf,


### PR DESCRIPTION
This PR adds support for PKCS#12 key files.

I had a hard time convincing relic to sign an Android application bundle with a key generated with keytool according to Google's instructions. The only thing that worked what using an unencrypted private key. Seeing that the import-key command already supports PKCS#12, I decided to add support for PKCS#12 key files (like the keystores created by keytool). Since modern keys use SHA256 instead of SHA1, I also had to find a replacement for the frozen and outdated golang.org/x/crypto/pkcs12 module.

Using the following `relic.yml`:
```
---
tokens:
  myfiletoken:
    type: file

keys:
  my_file_key:
    token: myfiletoken
    keyfile: ./keystore.jks
    ispkcs12: true
    x509certificate: ./certificate.pem
```
I could successfully sign an Android application bundle with our upload key.
```
./relic -c relic.yml sign -k my_file_key -f app.aab -T jar
Password for PKCS12: ******
Signed app.aab
```

I don't really know Go (yet). Comments are welcome.

I agree to the contributing guidelines, but I couldn't find the referenced contributor agreement file.