### PR TITLE
Initial support for signing MSIX and MSIX bundle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ Session.vim
 tags
 
 .vscode
+relic

--- a/lib/signappx/structs.go
+++ b/lib/signappx/structs.go
@@ -24,13 +24,13 @@ import (
 )
 
 const (
-	appxSignature     = "AppxSignature.p7x"
-	appxCodeIntegrity = "AppxMetadata/CodeIntegrity.cat"
-	appxBlockMap      = "AppxBlockMap.xml"
-	appxManifest      = "AppxManifest.xml"
-	appxContentTypes  = "[Content_Types].xml"
-
+	appxSignature      = "AppxSignature.p7x"
+	appxCodeIntegrity  = "AppxMetadata/CodeIntegrity.cat"
+	appxBlockMap       = "AppxBlockMap.xml"
+	appxManifest       = "AppxManifest.xml"
+	appxContentTypes   = "[Content_Types].xml"
 	bundleManifestFile = "AppxMetadata/AppxBundleManifest.xml"
+	resourcesPri       = "resources.pri"
 )
 
 type AppxSignature struct {

--- a/signers/appx/signer.go
+++ b/signers/appx/signer.go
@@ -61,7 +61,7 @@ func verify(f *os.File, opts signers.VerifyOpts) ([]*signers.Signature, error) {
 	if err != nil {
 		return nil, err
 	}
-	sig, err := signappx.Verify(f, size, opts.NoDigests)
+	sig, err := signappx.Verify(f, size, opts.NoDigests, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What 
Introduces initial support for signing MSIX/MSIX Bundle files as an addition over the existing signappx code.

## Why 
Microsoft has not published official guidelines of how MSIX signing actually works, but trial and error shows that for the most part it is compatible with APPX signing, which several tools implement, despite that not being documented either.

## How
- When processing MSIX bundle files, avoid adding .msix packages into the BlockMap and messing the hashes.
- When verifying the signature, do not enforce code integrity and catalog verification on resource packages, which do not and should not contain them.
- Fix the bin patch codepath where the initial patch start was determined prior to adding all the files in the output package, and therefore the central directory of the zip file could end up misplaced; instead, calculate the path start once we know its final position