### PR TITLE
Adjust section size when not aligned

### DIFF
--- a/lib/authenticode/pedigest.go
+++ b/lib/authenticode/pedigest.go
@@ -240,6 +240,7 @@ func readOptHeader(r io.Reader, d io.Writer, peStart int64, fh *pe.FileHeader) (
 		dd4Start = 128
 		hvals.sizeOfHdr = int64(opt.SizeOfHeaders)
 		hvals.sectionAlign = int(opt.SectionAlignment)
+		hvals.fileAlign = int(opt.FileAlignment)
 	case 0x20b:
 		// PE32+
 		var opt pe.OptionalHeader64
@@ -253,6 +254,7 @@ func readOptHeader(r io.Reader, d io.Writer, peStart int64, fh *pe.FileHeader) (
 		dd4Start = 144
 		hvals.sizeOfHdr = int64(opt.SizeOfHeaders)
 		hvals.sectionAlign = int(opt.SectionAlignment)
+		hvals.fileAlign = int(opt.FileAlignment)
 	default:
 		return nil, errors.New("unrecognized optional header magic")
 	}
@@ -293,6 +295,16 @@ func readSections(r io.Reader, d io.Writer, fh *pe.FileHeader, hvals *peHeaderVa
 		}
 		break
 	}
+	// Check for any sections that are not properly aligned
+	// and adjust alignment if required
+	for i := 0; i < len(sections); i++ {
+		if sections[i].SizeOfRawData == 0 {
+			continue
+		}
+		if v := sections[i].SizeOfRawData % uint32(hvals.fileAlign); v != 0 {
+			sections[i].SizeOfRawData += uint32(hvals.fileAlign) - v
+		}
+	}
 	// hash the padding after the section table
 	if _, err := io.CopyN(d, r, hvals.sizeOfHdr-secTblEnd); err != nil {
 		return nil, err
@@ -331,6 +343,8 @@ type peHeaderValues struct {
 	sizeOfHdr int64
 	// section alignment in memory
 	sectionAlign int
+	// section alignment in file
+	fileAlign int
 	// file offset and size of the certificate table
 	certStart, certSize int64
 }


### PR DESCRIPTION
When attempting to sign a PE file I encountered the following error:

```
ERROR: PE sections are out of order
```

Inspecting the sections of the PE file, I found that the listed size of one of the sections was not properly aligned:

```
file alignment: 512
section 0: start - 1536 | computed end: 8192 | size: 6656
section 1: start - 8192 | computed end: 8704 | size: 512
section 2: start - 8704 | computed end: 11776 | size: 3072
section 3: start - 11776 | computed end: 12800 | size: 1024
section 4: start - 12800 | computed end: 13312 | size: 512
section 6: start - 13312 | computed end: 15360 | size: 2048
section 7: start - 15360 | computed end: 15872 | size: 512
section 8: start - 15872 | computed end: 16384 | size: 512
section 9: start - 16384 | computed end: 19136 | size: 2752
section 9: unaligned by 320 bytes
section 10: start - 19456 | computed end: 19968 | size: 512
section 11: start - 19968 | computed end: 21504 | size: 1536
section 12: start - 21504 | computed end: 65024 | size: 43520
section 13: start - 65024 | computed end: 73216 | size: 8192
section 14: start - 73216 | computed end: 80896 | size: 7680
section 15: start - 80896 | computed end: 83968 | size: 3072
section 16: start - 83968 | computed end: 84992 | size: 1024
section 17: start - 84992 | computed end: 93184 | size: 8192
section 18: start - 93184 | computed end: 98304 | size: 5120
section 19: start - 98304 | computed end: 98816 | size: 512
```

Computing the end of section 9 points to `19136` but the reported start of section 10 is at `19456`. Checking the contents of the file it's visible there is still padding after the computed end of section 9:

![Screenshot_20230412_101914](https://user-images.githubusercontent.com/266674/231537645-a09ef634-b8b2-43cc-95c1-06b7524126aa.png)

And the reported start of section 10 shows at the end of the padding and at the proper alignment:

![Screenshot_20230412_101953](https://user-images.githubusercontent.com/266674/231538218-133c3a61-a041-450a-8cee-50dce1ba5df6.png)

By adjusting the reported size of the section to be properly aligned, the file can be fully read/digested and signed:

```
file alignment: 512
section 0: start - 1536 | computed end: 8192 | size: 6656
section 1: start - 8192 | computed end: 8704 | size: 512
section 2: start - 8704 | computed end: 11776 | size: 3072
section 3: start - 11776 | computed end: 12800 | size: 1024
section 4: start - 12800 | computed end: 13312 | size: 512
section 6: start - 13312 | computed end: 15360 | size: 2048
section 7: start - 15360 | computed end: 15872 | size: 512
section 8: start - 15872 | computed end: 16384 | size: 512
section 9: start - 16384 | computed end: 19136 | size: 2752
section 9: unaligned by 320 bytes
section 9: realigning...
section 10: start - 19456 | computed end: 19968 | size: 512
section 11: start - 19968 | computed end: 21504 | size: 1536
section 12: start - 21504 | computed end: 65024 | size: 43520
section 13: start - 65024 | computed end: 73216 | size: 8192
section 14: start - 73216 | computed end: 80896 | size: 7680
section 15: start - 80896 | computed end: 83968 | size: 3072
section 16: start - 83968 | computed end: 84992 | size: 1024
section 17: start - 84992 | computed end: 93184 | size: 8192
section 18: start - 93184 | computed end: 98304 | size: 5120
section 19: start - 98304 | computed end: 98816 | size: 512
Signed ./ruby.exe
```

And properly validated that the signature is correct:

![Screenshot_20230412_103645](https://user-images.githubusercontent.com/266674/231539197-4425e29f-4481-48d7-8da0-6b3d30b561d9.png)

I've also included the executable so it can be inspected if needed. If a different approach is preferred or whatever, please just let me know. Thanks so much!

[ruby.zip](https://github.com/sassoftware/relic/files/11214372/ruby.zip)
