### PR TITLE
return early if jar manifest has no sections

### DIFF
--- a/lib/signjar/manifest.go
+++ b/lib/signjar/manifest.go
@@ -47,6 +47,9 @@ func ParseManifest(manifest []byte) (files *FilesMap, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(sections) == 0 {
+		return nil, errors.New("manifest has no sections")
+	}
 	files = &FilesMap{
 		Order: make([]string, 0, len(sections)-1),
 		Files: make(map[string]http.Header, len(sections)-1),


### PR DESCRIPTION
If the manifest has no sections, Relic will crash with `runtime error: makeslice: cap out of range` when attempting to create the slice in the `Order` field.

This PR exits gracefully.