### PR TITLE
Replace unlicensed qur/ar with blakesmith/ar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
 	github.com/aws/aws-sdk-go-v2/service/kms v1.27.9
 	github.com/beevik/etree v1.3.0
+	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/cli/browser v1.2.0
 	github.com/go-asn1-ber/asn1-ber v1.5.5
@@ -28,7 +29,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc6
 	github.com/peterbourgon/diskv v2.0.1+incompatible
 	github.com/prometheus/client_golang v1.18.0
-	github.com/qur/ar v0.0.0-20130629153254-282534b91770
 	github.com/rs/zerolog v1.32.0
 	github.com/sassoftware/go-rpmutils v0.3.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/beevik/etree v1.3.0 h1:hQTc+pylzIKDb23yYprodCWWTt+ojFfUZyzU09a/hmU=
 github.com/beevik/etree v1.3.0/go.mod h1:aiPf89g/1k3AShMVAzriilpcE4R/Vuor90y83zVZWFc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb h1:m935MPodAbYS46DG4pJSv7WO+VECIWUQ7OJYSoTrMh4=
+github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874 h1:N7oVaKyGp8bttX0bfZGmcGkjz7DLQXhAn3DNd3T0ous=
 github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -211,8 +213,6 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/qur/ar v0.0.0-20130629153254-282534b91770 h1:A6sXY4zAECrW5Obx41PVMGr4kOw1rd1kmwcHa5M0dTg=
-github.com/qur/ar v0.0.0-20130629153254-282534b91770/go.mod h1:SjlYv2m9lpV0UW6K7lDqVJwEIIvSjaHbGk7nIfY8Hxw=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=

--- a/lib/signdeb/debsign.go
+++ b/lib/signdeb/debsign.go
@@ -31,7 +31,7 @@ import (
 	"github.com/sassoftware/relic/v7/lib/pgptools"
 	"github.com/sassoftware/relic/v7/lib/readercounter"
 
-	"github.com/qur/ar"
+	"github.com/blakesmith/ar"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/packet"
 )

--- a/lib/signdeb/verify.go
+++ b/lib/signdeb/verify.go
@@ -26,7 +26,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/qur/ar"
+	"github.com/blakesmith/ar"
 	"golang.org/x/crypto/openpgp"
 
 	"github.com/sassoftware/relic/v7/lib/pgptools"


### PR DESCRIPTION
This replaces the dependency on the unlicensed library `qur/ar` with the licensed `blakesmith/ar` which the former is forked from. `qur/ar` is only one commit ahead of `blakesmith/ar`. It doesn't look like that one change is relevant here (at least I hope it isn't). I've tested with `go test` and nothing seems to have broken.