### PR TITLE
Fix pecoff signing with post-header gap and unaligned last section

### DIFF
--- a/lib/authenticode/pedigest.go
+++ b/lib/authenticode/pedigest.go
@@ -308,8 +308,10 @@ func readSections(r io.Reader, d io.Writer, fh *pe.FileHeader, hvals *peHeaderVa
 			// some samples have a SizeOfHeaders that goes past the start of the first section
 			hvals.sizeOfHdr = p
 		}
-		// Adjust any sections that are not properly aligned
-		sections[i].SizeOfRawData = align32(section.SizeOfRawData, hvals.fileAlign)
+		// Adjust any sections that are not properly aligned, except for the last one, as it might be truncated
+		if i < len(sections)-1 {
+			sections[i].SizeOfRawData = align32(section.SizeOfRawData, hvals.fileAlign)
+		}
 	}
 	// hash the padding after the section table
 	if _, err := io.CopyN(d, r, hvals.sizeOfHdr-secTblEnd); err != nil {


### PR DESCRIPTION
When attempting to sign one of our binaries, we ran into two separate issues. The binary has two unusual features:

1. There is a "gap" between the file header and the start of the first section
2. The last section is not padded to the aligned size

The proposed changes fix the signing (and verification) for our binary.