### PR TITLE
Add signature caching for individual keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type KeyConfig struct {
 	Timestamp       bool     // If true, attach a timestamped countersignature when possible
 	Timestamper     string   // If set, use the named timestamper to countersign
 	Hide            bool     // If true, then omit this key from 'remote list-keys'
+	Memcache        []string // host:port of memcached to use for caching signatures
 
 	name  string
 	token *TokenConfig

--- a/doc/relic.yml
+++ b/doc/relic.yml
@@ -96,6 +96,10 @@ keys:
     # see `namedurls` below. Implies "timestamp: true".
     #timestamper: apple
 
+    # Optional memcache servers for memoizing signing requests
+    #memcache:
+    # - 127.0.0.1:11211
+
     # Clients with any of these roles can utilize this key
     roles: ["somegroup"]
 

--- a/internal/signinit/signinit.go
+++ b/internal/signinit/signinit.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sassoftware/relic/v8/signers"
 	"github.com/sassoftware/relic/v8/signers/sigerrors"
 	"github.com/sassoftware/relic/v8/token"
+	"github.com/sassoftware/relic/v8/token/signaturecache"
 )
 
 // InitKey loads the cert chain for a key
@@ -85,6 +86,15 @@ func Init(ctx context.Context, mod *signers.Signer, tok token.Token, keyName str
 		Audit: auditInfo,
 		Flags: flags,
 	}
+
+	// Use signature cache if configured
+	if len(kconf.Memcache) > 0 {
+		cert.PrivateKey, err = signaturecache.New(kconf, cert.PrivateKey.(crypto.Signer))
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	opts = opts.WithContext(ctx)
 	return cert, &opts, nil
 }

--- a/internal/signinit/signinit.go
+++ b/internal/signinit/signinit.go
@@ -89,7 +89,7 @@ func Init(ctx context.Context, mod *signers.Signer, tok token.Token, keyName str
 
 	// Use signature cache if configured
 	if len(kconf.Memcache) > 0 {
-		cert.PrivateKey, err = signaturecache.New(kconf, cert.PrivateKey.(crypto.Signer))
+		cert.PrivateKey, err = signaturecache.New(kconf, &opts, cert.PrivateKey.(crypto.Signer))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/token/signaturecache/signaturecache.go
+++ b/token/signaturecache/signaturecache.go
@@ -1,0 +1,76 @@
+// Copyright © Leonhard Oelke
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signaturecache
+
+import (
+	"crypto"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/sassoftware/relic/v8/config"
+)
+
+const (
+	// Settings for now are the same as the timestamp cache settings
+	memcacheTimeout = 1 * time.Second
+	memcacheExpiry  = 7 * 24 * time.Hour
+)
+
+type SignatureCache interface {
+	crypto.Signer
+}
+
+type signatureCache struct {
+	keyConf  *config.KeyConfig
+	signer   crypto.Signer
+	Memcache *memcache.Client
+}
+
+func New(keyConf *config.KeyConfig, signer crypto.Signer) (SignatureCache, error) {
+	selector := new(memcache.ServerList)
+	if err := selector.SetServers(keyConf.Memcache...); err != nil {
+		return nil, fmt.Errorf("parsing memcache servers: %w", err)
+	}
+	mc := memcache.NewFromSelector(selector)
+	mc.Timeout = memcacheTimeout
+	return &signatureCache{keyConf, signer, mc}, nil
+}
+
+func (c *signatureCache) Public() crypto.PublicKey {
+	return c.signer.Public()
+}
+
+func (c *signatureCache) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	cacheKey := fmt.Sprintf("%s-%x", c.keyConf.Name(), digest)
+
+	item, err := c.Memcache.Get(cacheKey)
+	if err == nil && item != nil {
+		return item.Value, nil
+	}
+
+	signature, err := c.signer.Sign(rand, digest, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = c.Memcache.Set(&memcache.Item{
+		Key:        cacheKey,
+		Value:      signature,
+		Expiration: int32(memcacheExpiry / time.Second),
+	})
+
+	return signature, nil
+}

--- a/token/signaturecache/signaturecache.go
+++ b/token/signaturecache/signaturecache.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/sassoftware/relic/v8/config"
+	"github.com/sassoftware/relic/v8/signers"
 )
 
 const (
@@ -35,18 +36,19 @@ type SignatureCache interface {
 
 type signatureCache struct {
 	keyConf  *config.KeyConfig
+	opts     *signers.SignOpts
 	signer   crypto.Signer
 	Memcache *memcache.Client
 }
 
-func New(keyConf *config.KeyConfig, signer crypto.Signer) (SignatureCache, error) {
+func New(keyConf *config.KeyConfig, opts *signers.SignOpts, signer crypto.Signer) (SignatureCache, error) {
 	selector := new(memcache.ServerList)
 	if err := selector.SetServers(keyConf.Memcache...); err != nil {
 		return nil, fmt.Errorf("parsing memcache servers: %w", err)
 	}
 	mc := memcache.NewFromSelector(selector)
 	mc.Timeout = memcacheTimeout
-	return &signatureCache{keyConf, signer, mc}, nil
+	return &signatureCache{keyConf, opts, signer, mc}, nil
 }
 
 func (c *signatureCache) Public() crypto.PublicKey {
@@ -54,10 +56,11 @@ func (c *signatureCache) Public() crypto.PublicKey {
 }
 
 func (c *signatureCache) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	cacheKey := fmt.Sprintf("%s-%x", c.keyConf.Name(), digest)
+	cacheKey := fmt.Sprintf("sig-%s-%x", c.keyConf.Name(), digest)
 
 	item, err := c.Memcache.Get(cacheKey)
 	if err == nil && item != nil {
+		c.opts.Audit.Attributes["sig.cache"] = "hit"
 		return item.Value, nil
 	}
 
@@ -72,5 +75,6 @@ func (c *signatureCache) Sign(rand io.Reader, digest []byte, opts crypto.SignerO
 		Expiration: int32(memcacheExpiry / time.Second),
 	})
 
+	c.opts.Audit.Attributes["sig.cache"] = "miss"
 	return signature, nil
 }


### PR DESCRIPTION
These patches add the option to cache the signatures generated by keys. We implemented this, because our internal processes are not ... optimal, and thus some binaries are getting signed repeatedly in CI/CD without changing.
Since we pay per signature, this will hopefully help us (and others in the same situation) to save some money.

I added the memcache option to individual keys instead of the key section or anywhere else because:

* It was convenient
* We only care for caching on one of our keys, while the others can do without

Since i was not sure if you would want to add the feature, i did not spend time on prometheus metrics. If you are interested in merging this, i can add those as well.