### PR TITLE
Add zstd compression for debian control files.

### DIFF
--- a/lib/signdeb/control.go
+++ b/lib/signdeb/control.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/xi2/xz"
+	"github.com/klauspost/compress/zstd"
 )
 
 type PackageInfo struct {
@@ -45,6 +46,8 @@ func parseControl(r io.Reader, ext string) (*PackageInfo, error) {
 		r = bzip2.NewReader(r)
 	case ".xz":
 		r, err = xz.NewReader(r, 0)
+	case ".zst":
+		r, err = zstd.NewReader(r)
 	case "":
 	default:
 		err = errors.New("unrecognized compression on control.tar")


### PR DESCRIPTION
Newer debian introduced new compression method for control files.

The license used by klauspost/compress (Apache) seems to be compatible with relic (https://github.com/klauspost/compress/blob/master/LICENSE)

The interface is also compatible.