### PR TITLE
Initial "dgst" implementation for freebsd and alpine packages.

### DIFF
--- a/main_client.go
+++ b/main_client.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/sassoftware/relic/v8/signers/vsix"
 	_ "github.com/sassoftware/relic/v8/signers/xap"
 	_ "github.com/sassoftware/relic/v8/signers/xar"
+	_ "github.com/sassoftware/relic/v8/signers/blob"
 )
 
 var (

--- a/signers/blob/signer.go
+++ b/signers/blob/signer.go
@@ -1,0 +1,92 @@
+package blob
+
+import (
+
+	"io"
+	"os"
+	"fmt"
+	"errors"
+	"crypto"
+	"crypto/rand"
+
+	"github.com/rs/zerolog"
+	"github.com/sassoftware/relic/v8/lib/audit"
+	"github.com/sassoftware/relic/v8/lib/certloader"
+	"github.com/sassoftware/relic/v8/signers"
+	"github.com/sassoftware/relic/v8/lib/atomicfile"
+	"github.com/sassoftware/relic/v8/lib/binpatch"
+
+)
+
+
+var BlobSigner = &signers.Signer{
+	Name:	    "blob",
+	CertTypes:  signers.CertTypePgp,
+	AllowStdin: true,
+	Transform:  transform,
+	Sign:	    sign,
+	Verify:	    verify,
+}
+
+func init() {
+	signers.Register(BlobSigner)
+}
+
+func formatLog(attrs *audit.Info) *zerolog.Event {
+	return attrs.AttrsForLog("blob.")
+}
+
+func sign(r io.Reader, cert *certloader.Certificate, opts signers.SignOpts) ([]byte, error) {
+	privKey := cert.PrivateKey.(crypto.Signer)
+	hash := opts.Hash.New()
+	if _, err := io.Copy(hash, r); err != nil {
+		return nil, err
+	}
+	digest := hash.Sum(nil)
+	return privKey.Sign(rand.Reader, digest, opts.Hash)
+}
+
+func verify(f *os.File, opts signers.VerifyOpts) ([]*signers.Signature, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type blobTransformer struct {
+	input *os.File
+}
+
+func transform(f *os.File, opts signers.SignOpts) (signers.Transformer, error) {
+	//save input filename for later use
+	return &blobTransformer{f}, nil
+}
+
+func (t blobTransformer) GetReader() (io.Reader, error) {
+	if _, err := t.input.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seeking input file: %w", err)
+	}
+	return t.input, nil
+}
+
+func (t *blobTransformer) Apply(dest, mimeType string, result io.Reader) error {
+	var output string
+	// avoid mangling input file
+	if t.input.Name() == dest {
+		output = "-"
+	} else {
+		output = dest
+	}
+
+	// copy from default implementation in signers/transform
+	if mimeType == binpatch.MimeType {
+		return signers.ApplyBinPatch(t.input, dest, result)
+	}
+	f, err := atomicfile.WriteAny(output)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(f, result); err != nil {
+		return err
+	}
+	t.input.Close()
+	return f.Commit()
+}
+


### PR DESCRIPTION
I'm using relic to sign a bunch of linux packages. Deb, rpm, apk and (not quite linux:) freebsd pkg.
The two latter use openssl dgst or a wrapper for it 
Here are sources for APK: https://github.com/alpinelinux/abuild/blob/292a03128e6c08dae5194f0794fe0d55450171ff/abuild-sign.in#L35
And here is a man page that describes BSD approach to signing repos: [pkg-repo](https://man.freebsd.org/cgi/man.cgi?pkg-repo(8))

The process is roughly the same: one  needs an rsa key and pksc1v1.5 signature. Not quite sure if I'm correct in this naming but [Crypto.Signer](https://pkg.go.dev/crypto#Signer) does exactly what's needed.

The implementation is quite straightforward: just get the key and sign. There is no filetype associated with the signer. Nor there is a way to verify the signature: if I get it right - currently there is no way to pass specific key to use for verification. But `openssl pkeyutl` does that for me.

Let me know if there is anything I can improve in this code. 